### PR TITLE
add context menu on reading mode / image preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ webpack.dev.js
 main.js.LICENSE.txt
 
 .env
+.vscode


### PR DESCRIPTION
Creates context menu when right clicking images in reading mode (or live preview of the image instead of the link in editing mode). I had to duplicate your code for the menu options, so it could probably be refactored, but I wanted to introduce minimal changes here. 