### PR TITLE
Enforce UTF8 Encoding in second window

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -86,6 +86,12 @@ class NamedWindow {
 
     buildHead() {
         this.head = createEl("head");
+
+        this.head.createEl("meta", {
+            type: "charset",
+            attr: { charset: "utf-8"}
+        });
+
         this.head.createEl("link", {
             href: "app://obsidian.md/app.css",
             type: "text/css",


### PR DESCRIPTION
This fixes #27 and will ensure, characters like German Umlauts will shown properly in new window

BEGIN_COMMIT_OVERRIDE
fix: Enforce UTF8 Encoding in second window
END_COMMIT_OVERRIDE