### PR TITLE
feat: add custom window name setting

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,5 +1,7 @@
 export interface PluginSettings {
     saveWindowLocations: boolean;
+    useCustomWindowName: boolean;
+    customWindowName: string;
     /**
      * indexed by configured window name, plus the default window at "DEFAULT"
      */ 


### PR DESCRIPTION
## Pull Request Description

Add some settings to have a custom window name instead of the filename. Use the named window keys when opening with a named window.
Quite useful when you want to show your TTRPG players a picture of something important they don't know the name of yet without spoiling them.

## Changes Proposed

Add two settings: `Use Custom Window Name` and `Custom Window Name`.

- [ ] Use Custom Window Name
- [ ] Custom Window Name

## Related Issues

None

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully.
- [ ] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

None, can make some if needed.

## Additional Notes

None